### PR TITLE
feat: Add Bare-metal C "Hello, World!" Program

### DIFF
--- a/c/hello/Makefile
+++ b/c/hello/Makefile
@@ -1,0 +1,41 @@
+# Toolchain
+CC      = riscv64-unknown-elf-gcc
+OBJCOPY = riscv64-unknown-elf-objcopy
+QEMU    = qemu-system-riscv64
+
+# Flags
+# Thêm cờ -Wall để bật cảnh báo và -g để debug
+CFLAGS  = -nostdlib -march=rv64imac -mabi=lp64 -Wall -g -mcmodel=medlow
+
+# Source files
+# Liệt kê tất cả các file .o cần thiết
+OBJS    = boot.o hello_world.o
+
+# Targets
+TARGET  = hello_world
+
+all: $(TARGET).bin
+
+# --- Quy tắc liên kết (Linking Rule) ---
+# Để tạo file .elf, chúng ta cần tất cả các file .o
+$(TARGET).elf: $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) -T linker.ld
+
+# --- Quy tắc biên dịch (Compilation Rules) ---
+# Quy tắc chung để tạo file .o từ file .c
+boot.o: boot.S
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Quy tắc chung để tạo file .o từ file .S
+hello_world.o: hello_world.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# --- Quy tắc tiện ích (Utility Rules) ---
+$(TARGET).bin: $(TARGET).elf
+	$(OBJCOPY) -O binary $< $@
+
+run: $(TARGET).bin
+	$(QEMU) -machine virt -nographic -bios none -kernel $<
+
+clean:
+	rm -f *.o *.elf *.bin

--- a/c/hello/README.md
+++ b/c/hello/README.md
@@ -1,0 +1,72 @@
+# Bare-metal "Hello, World\!" for RISC-V
+
+### 1\. Giới thiệu
+
+Đây là một dự án lập trình bare-metal đơn giản cho kiến trúc RISC-V, được xây dựng dựa trên nền tảng của repo `wirehack`. Mục tiêu của dự án là chuyển đổi chương trình "Hello, World\!" từ Assembly thuần túy sang C, sau đó biên dịch và chạy nó trên trình giả lập QEMU.
+
+Dự án này là một bài học thực tế về quá trình khởi động (boot sequence), giao tiếp với phần cứng ở cấp độ thấp (Memory-Mapped I/O) và sử dụng các công cụ lập trình hệ thống như trình biên dịch (GCC) và trình liên kết (linker).
+
+### 2\. Cấu trúc thư mục
+
+```
+c/
+├── Makefile          # Script tự động hóa quá trình biên dịch và chạy
+├── boot.S            # Mã khởi động Assembly
+├── hello_world.c     # Mã nguồn C
+└── linker.ld         # File chỉ định cách sắp xếp bộ nhớ
+```
+
+### 3\. Các file chính
+
+#### a) `boot.S` - Mã khởi động
+
+File này chứa mã Assembly đơn giản, đóng vai trò là "cầu nối" giữa CPU và chương trình C.
+
+  - `_start`: Điểm khởi đầu mà CPU nhảy tới khi khởi động.
+  - `la sp, __stack_top`: Thiết lập con trỏ stack (`sp`) để chương trình C có thể hoạt động.
+  - `call main`: Gọi hàm `main` trong chương trình C của chúng ta.
+  - `get_message`: Một hàm Assembly đặc biệt để tải địa chỉ của chuỗi "Hello, World\!" một cách an toàn, tránh lỗi `relocation truncated`.
+
+#### b) `hello_world.c` - Chương trình C
+
+Chương trình này viết bằng C để in ra một chuỗi ký tự bằng cách ghi trực tiếp vào địa chỉ bộ nhớ của cổng UART giả lập.
+
+  - **`#include <stdint.h>`**: Cần thiết để sử dụng kiểu dữ liệu có kích thước cố định như `uint8_t`.
+  - **`volatile`**: Đảm bảo trình biên dịch không tối ưu hóa các lệnh ghi vào địa chỉ của phần cứng.
+  - **`uart_puts`**: Hàm tùy chỉnh để gửi chuỗi ký tự từng byte một.
+  - **`main`**: Lấy địa chỉ chuỗi từ hàm Assembly, in nó ra màn hình và sau đó đi vào vòng lặp vô tận.
+
+#### c) `linker.ld` - Script liên kết
+
+File này hướng dẫn trình liên kết cách sắp xếp các phần của chương trình vào bộ nhớ RAM.
+
+  - **`ENTRY(_start)`**: Chỉ định điểm vào của chương trình.
+  - **`0x80000000`**: Đặt địa chỉ cơ sở cho toàn bộ chương trình.
+  - **`.text`, `.rodata`, `.data`, `.bss`**: Sắp xếp các khu vực mã lệnh, dữ liệu chỉ đọc, dữ liệu đã khởi tạo và dữ liệu chưa khởi tạo một cách hợp lý.
+
+#### d) `Makefile`
+
+Tự động hóa toàn bộ quá trình:
+
+  - **`all`**: Mục tiêu mặc định để tạo ra file `.bin` cuối cùng.
+  - **`hello_world.elf: boot.o hello_world.o`**: Quy tắc liên kết, gộp cả `boot.o` và `hello_world.o` thành một file thực thi duy nhất.
+  - **`-T linker.ld`**: Chỉ định sử dụng file `linker.ld` để kiểm soát bộ nhớ.
+  - **`run`**: Lệnh chạy chương trình trên QEMU.
+
+### 4\. Hướng dẫn sử dụng
+
+Để biên dịch và chạy chương trình, hãy điều hướng đến thư mục `c/` và sử dụng các lệnh sau:
+
+```bash
+# Xóa các file cũ
+make clean
+
+# Biên dịch, liên kết và chạy chương trình
+make run
+```
+
+### 5\. Những bài học quan trọng
+
+1.  **Lập trình bare-metal đòi hỏi sự kiểm soát hoàn toàn:** Không có hệ điều hành, mọi thứ phải được thiết lập thủ công.
+2.  **Lỗi `relocation truncated`:** Lỗi này xảy ra khi trình liên kết không thể truy cập dữ liệu vì nó quá xa mã lệnh. Cách giải quyết là sử dụng một `linker script` để sắp xếp lại bộ nhớ.
+3.  **Assembly là công cụ mạnh mẽ:** Khi C không thể làm được việc, Assembly có thể được sử dụng để thực hiện các thao tác cấp thấp một cách chính xác.

--- a/c/hello/boot.S
+++ b/c/hello/boot.S
@@ -1,0 +1,25 @@
+    .global _start
+_start:
+    la   sp, __stack_top
+    call main
+loop:
+    j loop
+
+# ----- Hàm để lấy địa chỉ của chuỗi -----
+# Hàm này sẽ được gọi từ C
+    .global get_message
+get_message:
+    la a0, message # Tải địa chỉ của chuỗi 'message' vào thanh ghi a0
+    ret            # Trả về giá trị trong a0
+
+# ----- Định nghĩa dữ liệu -----
+    .section .rodata
+message:
+    .string "Hello from bare-metal C!\n"
+
+# ----- Định nghĩa vùng nhớ cho Stack -----
+    .section .bss
+    .align 4
+__stack_bottom:
+    .space 4096
+__stack_top:

--- a/c/hello/hello_world.c
+++ b/c/hello/hello_world.c
@@ -1,0 +1,30 @@
+// File: c/hello_world.c
+
+#include <stdint.h>
+
+// Khai báo hàm Assembly sẽ trả về con trỏ chuỗi
+extern const char* get_message();
+
+#define UART_BASE 0x10000000
+
+void uart_putc(char c) {
+    volatile uint8_t *uart = (volatile uint8_t *)UART_BASE;
+    *uart = c;
+}
+
+void uart_puts(const char *s) {
+    while (*s) {
+        uart_putc(*s++);
+    }
+}
+
+int main() {
+    // Lấy con trỏ đến chuỗi từ hàm Assembly
+    const char* my_message = get_message();
+
+    uart_puts(my_message);
+
+    while (1);
+
+    return 0;
+}

--- a/c/hello/linker.ld
+++ b/c/hello/linker.ld
@@ -1,0 +1,24 @@
+ENTRY(_start)
+
+OUTPUT_ARCH(riscv)
+
+SECTIONS
+{
+    . = 0x80000000;
+
+    .text : {
+        *(.text)
+        *(.rodata)
+    }
+
+    .data : {
+        *(.data)
+    }
+
+    .bss : {
+        *(.bss)
+    }
+
+    . = ALIGN(4);
+    _end = .;
+}


### PR DESCRIPTION
### Summary

This PR introduces a bare-metal "Hello, World!" program written in C, capable of running on the RISC-V QEMU `virt` machine. It serves as a foundational example of how to transition from pure assembly to a C environment in a bare-metal context.

### The Problem

The initial `asm/hello` example was written entirely in assembly. While effective, it's not practical for larger applications. The primary challenge was to establish a proper environment for C code to execute, which includes:
1.  Setting up a valid stack.
2.  Calling the `main` function from an assembly entry point.
3.  Handling low-level I/O (like printing to the console) without a standard library.
4.  Resolving symbol relocation errors (`relocation truncated to fit`) that occurred due to the default compiler and linker behavior.

### The Solution

This PR addresses the challenges by implementing the following components:

* **`boot.S`**: A minimal assembly startup file that:
    * Defines the `_start` entry point.
    * Initializes the stack pointer (`sp`).
    * Calls the C `main` function.
    * Includes a `get_message` helper function to safely load the address of a string, bypassing compiler relocation issues.

* **`hello_world.c`**: The main application logic, which:
    * Communicates with the QEMU UART via Memory-Mapped I/O (MMIO) at address `0x10000000`.
    * Calls the `get_message` assembly function to retrieve the string pointer before printing.

* **`linker.ld`**: A custom linker script that:
    * Sets the program's base address to `0x80000000`.
    * Explicitly places the `.text` and `.rodata` sections together to ensure code and constant data are close in memory.
    * Defines the `.bss` section for the stack.

* **`Makefile`**: An updated build script that:
    * Compiles both `.c` and `.S` source files into separate object files.
    * Links the object files together using the custom `linker.ld` script to produce the final `.elf` and `.bin` files.

### How to Test

1.  Navigate to the `c/` directory.
2.  Run `make clean` to remove any old artifacts.
3.  Run `make run`.
4.  The QEMU console should display the message: `Hello from bare-metal C!`

This implementation provides a robust and well-documented foundation for future bare-metal C development on this platform.