### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.bin
 *.elf
 *.o
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
This PR adds `.DS_Store` to the `.gitignore` file to prevent macOS system files from being tracked in the repository.

## Changes
- Added `.DS_Store` entry to `.gitignore` with a comment explaining it's for macOS system files

## Why
macOS automatically creates `.DS_Store` files in directories to store custom attributes and folder settings. These files should not be tracked in version control as they are system-specific and can cause unnecessary noise in commits.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author